### PR TITLE
Fixed Gst.init()

### DIFF
--- a/videosequence/__init__.py
+++ b/videosequence/__init__.py
@@ -14,7 +14,7 @@ gi.require_version('GstApp', '1.0')
 from gi.repository import Gst, GstApp
 
 # Initialise GStreamer
-Gst.init()
+Gst.init(None)
 
 LOG = logging.getLogger()
 STATE_CHANGE_TIMEOUT = 1 * Gst.SECOND


### PR DESCRIPTION
I couldn't `import videosequence` because of `TypeError: Gst.init() takes exactly 1 argument (0 given)` so I added a `None` argument like on [this example](https://adnanalamkhan.wordpress.com/2015/03/01/using-gstreamer-1-0-with-python/). Now it works.