### PR TITLE
Read file as binary and explicitly decode from UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import os
 from setuptools import setup, find_packages
 
 def read_file(path):
-    with open(os.path.join(os.path.dirname(__file__), path), "r") as fobj:
-        return fobj.read()
+    with open(os.path.join(os.path.dirname(__file__), path), "rb") as fobj:
+        return fobj.read().decode('utf-8',  'ignore')
 
 setup(
     name="videosequence",


### PR DESCRIPTION
This solves `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3769: ordinal not in range(128)` when trying to install via pip (version 9.0.1, Python 3.5.2)